### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: msfjarvis/setup-android@1.0
-      with:
-        args: "./gradlew check assembleDebug"
+    - run: ./gradlew check assembleDebug


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.